### PR TITLE
Make rake tasks

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,6 @@ class ApplicationController < ActionController::API
 
   private
     def record_not_found
-      format.json { render status: :not_found, json: { errors: "Record not found" } }
+      render status: :not_found, json: { errors: "Record not found" } 
     end
 end

--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -1,18 +1,22 @@
 class LinksController < ApplicationController
 
   def show
-    @link = Link.find_by(short_url: params[:short_url])
+    @link = Link.find_by!(short_url: params[:short_url])
     render status: :ok, json: { url: @link.url }
 
   end
 
   def create
-    @link = Link.new(link_params)
-    @link.short_url = @link.generate_short_url
-    if @link.save
-      render status: :ok, json: { link: @link }
+    @link = Link.find_or_initialize_by(link_params)
+    if @link.new_record?
+      @link.short_url = @link.generate_short_url
+      if @link.save
+        render status: :ok, json: { short_url: @link.short_url }
+      else
+        render status: :unprocessable_entity, json: { errors: @link.errors.full_messages }
+      end
     else
-      render status: :unprocessable_entity, json: { errors: @link.errors.full_messages }
+      render status: :ok, json: { short_url: @link.short_url }
     end
   end
 

--- a/lib/tasks/app.rake
+++ b/lib/tasks/app.rake
@@ -1,0 +1,29 @@
+namespace :app do
+  
+  routes = Rails.application.routes.url_helpers
+  session = ActionDispatch::Integration::Session.new(Rails.application)
+  
+  desc "GET SHORT URL"
+  task encode: :environment do 
+    url = ENV['URL']
+    session.post("https://localhost:3000#{routes.links_path}", params: {
+      link: { url: url}
+    })
+    response = JSON.parse(session.response.body)
+    short_url = response["short_url"]
+    puts "The shortened url of #{url} is https://short.is/#{short_url}."
+  end
+
+  desc "GET ORIGINAL URl"
+  task decode: :environment do
+    input = ENV['SHORTURL']
+    short_url = input[input.length-8, input.length]
+    res = session.get "https://localhost:3000#{routes.short_url_path(short_url)}"
+    response = JSON.parse(session.response.body)
+    if res == 404
+      puts "No original url was found for the  short url #{input}."
+    else
+      puts "The original url of short url #{input} is #{response['url']}."
+    end
+  end
+end

--- a/test/controllers/links_controller_test.rb
+++ b/test/controllers/links_controller_test.rb
@@ -4,15 +4,24 @@ class LinksControllerTest < ActionDispatch::IntegrationTest
 
   test "should be able to create link" do
     assert_difference 'Link.count', 1 do
-      post links_path, params: { link: { url: "https://bigbinary.com/carrer" }}
+      post links_path, params: { link: { url: "https://bigbinary.com/products" }}
     end
     assert_response :ok
+
+  end
+
+  test "should not create link if it already exist?" do
+    assert_difference 'Link.count', 0 do
+      post links_path, params: { link: { url: links(:one).url }}
+    end
+    assert_response :ok
+    assert_equal json_body["short_url"], links(:one).short_url
   end
 
   test "should show original url" do
     get short_url_path(links(:one).short_url)
     assert_response :ok
-    assert_equal "https://bigbinary.com/jobs", json_body["url"]
+    assert_equal links(:one).url, json_body["url"]
   end
 
 end


### PR DESCRIPTION
- Build rake tasks: encode, decode
- Fixed issue that if the original URL already exists in the database then instead of creating a new record for the same URL, it will give already existed short_url
- Added test case "should not create link if it already exist?"